### PR TITLE
feat: add initial implementation for workspace commands

### DIFF
--- a/lua/telescope-code-actions/models/code_action.lua
+++ b/lua/telescope-code-actions/models/code_action.lua
@@ -11,6 +11,7 @@ local CodeAction = {
 	},
 	meta = {
 		client_id = nil,
+		bufnr = nil,
 	},
 }
 
@@ -22,12 +23,19 @@ function CodeAction:new(server_action, meta)
 end
 
 function CodeAction:apply()
+	local client = vim.lsp.get_client_by_id(self.meta.client_id)
+	local command = self.server_action.command
+	local edit = self.server_action.edit
 	if self.server_action.command then
-		vim.lsp.util.execute_command(self.server_action.command)
+		local params = {
+			command = command.command,
+			arguments = command.arguments,
+			wordDoneToken = command.wordDoneToken,
+		}
+		client.request("workspace/executeCommand", params, nil, self.meta.bufnr)
 	end
-	if self.server_action.edit then
-		---@diagnostic disable-next-line: undefined-field
-		vim.lsp.util.apply_workspace_edit(self.server_action.edit, vim.opt.fileencoding:get())
+	if edit then
+		vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
 	end
 end
 

--- a/lua/telescope-code-actions/utils/init.lua
+++ b/lua/telescope-code-actions/utils/init.lua
@@ -51,11 +51,13 @@ M.get_code_actions = function()
 			return nil
 		end
 
+		local bufnr = vim.api.nvim_get_current_buf()
 		for _, server_action in pairs(result) do
 			table.insert(
 				code_actions,
 				CodeAction:new(server_action, {
 					client_id = client.id,
+					bufnr = bufnr,
 				})
 			)
 		end


### PR DESCRIPTION
This should work for workspace commands that follow the lsp spec.
Other commands are not included yet [vim.lsp.commands](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/lsp.lua#L2295)