### PR TITLE
fix: error on nocodeaction

### DIFF
--- a/lua/telescope-code-actions/utils/init.lua
+++ b/lua/telescope-code-actions/utils/init.lua
@@ -47,6 +47,7 @@ M.get_code_actions = function()
 		end
 
 		if error then
+			M.notify(error, vim.log.levels.ERROR)
 			return nil
 		end
 

--- a/lua/telescope-code-actions/utils/init.lua
+++ b/lua/telescope-code-actions/utils/init.lua
@@ -42,13 +42,16 @@ M.get_code_actions = function()
 		local result = response.result
 		local error = response.err
 
+		if error ~= nil and error["code"] == -32601 then
+			M.notify("Current LSP server has no code actions method", vim.log.levels.ERROR)
+		end
+
 		if error then
-			vim.notify(error)
 			return nil
 		end
 
 		if result == nil then
-			return nil
+			return {}
 		end
 
 		for _, server_action in pairs(result) do

--- a/lua/telescope-code-actions/utils/init.lua
+++ b/lua/telescope-code-actions/utils/init.lua
@@ -42,12 +42,11 @@ M.get_code_actions = function()
 		local result = response.result
 		local error = response.err
 
-		if error ~= nil and error["code"] == -32601 then
+		if error ~= nil and error.code == -32601 then
 			M.notify("Current LSP server has no code actions method", vim.log.levels.ERROR)
 		end
 
 		if error then
-			M.notify(error, vim.log.levels.ERROR)
 			return nil
 		end
 

--- a/lua/telescope/_extensions/code_actions.lua
+++ b/lua/telescope/_extensions/code_actions.lua
@@ -10,31 +10,32 @@ local open_menu = function(opts)
 
 	local code_actions = U.get_code_actions()
 
-	if code_actions ~= nil then
-		pickers
-			.new(opts, {
-				prompt_title = "Code Actions",
-				finder = finders.new_table({
-					results = code_actions,
-					entry_maker = function(entry)
-						return {
-							value = entry,
-							display = entry.server_action.title,
-							ordinal = entry.server_action.title,
-						}
-					end,
-				}),
-				attach_mappings = function(prompt_bufnr, map)
-					actions.select_default:replace(function()
-						actions.close(prompt_bufnr)
-						local selection = action_state.get_selected_entry()
-						selection.value:apply()
-					end)
-					return true
-				end,
-			})
-			:find()
+	if code_actions == nil then
+		return
 	end
+	pickers
+		.new(opts, {
+			prompt_title = "Code Actions",
+			finder = finders.new_table({
+				results = code_actions,
+				entry_maker = function(entry)
+					return {
+						value = entry,
+						display = entry.server_action.title,
+						ordinal = entry.server_action.title,
+					}
+				end,
+			}),
+			attach_mappings = function(prompt_bufnr, map)
+				actions.select_default:replace(function()
+					actions.close(prompt_bufnr)
+					local selection = action_state.get_selected_entry()
+					selection.value:apply()
+				end)
+				return true
+			end,
+		})
+		:find()
 end
 
 return require("telescope").register_extension({

--- a/lua/telescope/_extensions/code_actions.lua
+++ b/lua/telescope/_extensions/code_actions.lua
@@ -10,29 +10,31 @@ local open_menu = function(opts)
 
 	local code_actions = U.get_code_actions()
 
-	pickers
-		.new(opts, {
-			prompt_title = "Code Actions",
-			finder = finders.new_table({
-				results = code_actions,
-				entry_maker = function(entry)
-					return {
-						value = entry,
-						display = entry.server_action.title,
-						ordinal = entry.server_action.title,
-					}
+	if code_actions ~= nil then
+		pickers
+			.new(opts, {
+				prompt_title = "Code Actions",
+				finder = finders.new_table({
+					results = code_actions,
+					entry_maker = function(entry)
+						return {
+							value = entry,
+							display = entry.server_action.title,
+							ordinal = entry.server_action.title,
+						}
+					end,
+				}),
+				attach_mappings = function(prompt_bufnr, map)
+					actions.select_default:replace(function()
+						actions.close(prompt_bufnr)
+						local selection = action_state.get_selected_entry()
+						selection.value:apply()
+					end)
+					return true
 				end,
-			}),
-			attach_mappings = function(prompt_bufnr, map)
-				actions.select_default:replace(function()
-					actions.close(prompt_bufnr)
-					local selection = action_state.get_selected_entry()
-					selection.value:apply()
-				end)
-				return true
-			end,
-		})
-		:find()
+			})
+			:find()
+	end
 end
 
 return require("telescope").register_extension({


### PR DESCRIPTION
This fixes the errors that would come up if:

1.  one tries to uses this plugin on a line where no code actions are available (now just shows an empty code actions telescope) and 
2. and when the current lsp server has no code actions method (now just shows an error)